### PR TITLE
Always use TLS MITM for CONNECT if possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The JWT forward proxy is used to sign outgoing requests with a JWT using a priva
 - Ability to append static claims via config
 - Ability to read dynamic claims out of a request header and turn them into JWT claims
 
+### Limitations
+
+- When the proxy is configured to use MITM SSL, the `CONNECT` tunneling mechanism is only available to forward HTTPS requests. By default, most clients exclusively use `CONNECT` for HTTPS requests, which is 100% supported.
+
 ## JWT Reverse Proxy
 
 The JWT reverse proxy is used to verify incoming requests that were signed by the forward proxy.


### PR DESCRIPTION
CONNECT is usually used by clients when the target is over HTTPs. As
long as we've a CA key pair specified, the CONNECT handler should do TLS
MITM.

The target port doesn't actually matter. We assume that clients
use the right method to talk with the proxy. In other words, we assume
that CONNECT is not used when forwarding to a plain HTTP target. This
use-case should be very minimal / non-existent.