### PR TITLE
Return 401 Unauthorized, when jwt is invalid

### DIFF
--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -123,7 +123,7 @@ func NewJWTVerifierHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, e
 	handler := func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
 		signedClaims, err := Verify(r, keyServer, nonceStorage, cfg.Audience.URL, cfg.MaxSkew, cfg.MaxTTL)
 		if err != nil {
-			return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusForbidden, fmt.Sprintf("jwtproxy: unable to verify request: %s", err))
+			return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusUnauthorized, fmt.Sprintf("jwtproxy: unable to verify request: %s", err))
 		}
 
 		// Run through the claims verifiers.


### PR DESCRIPTION
When trying to acces jwtproxy with an invalid JWT, we should instead of returning Forbidden 403, return 401 Unauthorized.
