### PR TITLE
add support for basic auth

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -72,7 +72,11 @@ func Verify(req *http.Request, keyServer keyserver.Reader, nonceVerifier noncest
 	// Extract token from request.
 	token, err := oidc.ExtractBearerToken(req)
 	if err != nil {
-		return nil, errors.New("No JWT found")
+                username, password, ok := req.BasicAuth()
+                if !ok && username == "oauth2" {
+		        return nil, errors.New("No JWT found")
+                }
+		token = password
 	}
 
 	// Parse token.


### PR DESCRIPTION
This PR allows a client to send the JWT with basic authentication.
User is hardcoded to oauth2
Password is JWT