### PR TITLE
Make unexpected errors in JWT proxy more descriptive

### DIFF
--- a/jwt/keyserver/keyregistry/keyregistry.go
+++ b/jwt/keyserver/keyregistry/keyregistry.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -79,7 +80,13 @@ func (krc *client) GetPublicKey(issuer string, keyID string) (*key.PublicKey, er
 		case http.StatusForbidden:
 			return nil, keyserver.ErrPublicKeyExpired
 		default:
-			return nil, keyserver.ErrUnkownResponse
+			bodyBytes, bodyErr := ioutil.ReadAll(resp.Body)
+			if bodyErr != nil {
+				bodyBytes = []byte{}
+			}
+
+			rerr := fmt.Errorf("Got unexpected response from key server: %v: %s", resp.StatusCode, string(bodyBytes))
+			return nil, rerr
 		}
 	}
 

--- a/jwt/keyserver/keyserver.go
+++ b/jwt/keyserver/keyserver.go
@@ -28,7 +28,6 @@ import (
 var (
 	ErrPublicKeyNotFound = errors.New("Could not find any matching public key")
 	ErrPublicKeyExpired  = errors.New("Key has expired.")
-	ErrUnkownResponse    = errors.New("Unexpected response.")
 )
 
 type ReaderConstructor func(config.RegistrableComponentConfig) (Reader, error)

--- a/jwt/privatekey/autogenerated/autogenerated.go
+++ b/jwt/privatekey/autogenerated/autogenerated.go
@@ -93,8 +93,8 @@ func constructor(registrableComponentConfig config.RegistrableComponentConfig, s
 				log.Debug("Public Key not found - generating a new key")
 			case keyserver.ErrPublicKeyExpired:
 				log.WithError(err).Fatal("Public key has expired; delete or renew it.")
-			case keyserver.ErrUnkownResponse:
-				log.WithError(err).Fatal("Uknown response from the keyserver.")
+			default:
+				log.WithError(err).Fatal(err.Error())
 			}
 		}
 	} else {


### PR DESCRIPTION
This allows downstream users to better debug when their key server isn't working