### PR TITLE
make socket 0777 permissions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ func (cfg *VerifierProxyConfig) UnmarshalYAML(unmarshal func(interface{}) error)
 	tempCfg := DefaultVerifierProxyConfig{
 		Enabled:         true,
 		ListenAddr:      ":8082",
+		SocketPermission: 0755,
 		ShutdownTimeout: 5 * time.Second,
 		Verifier: VerifierConfig{
 			MaxSkew: 5 * time.Minute,
@@ -95,6 +96,7 @@ type Config struct {
 type VerifierProxyConfig struct {
 	Enabled         bool           `yaml:"enabled"`
 	ListenAddr      string         `yaml:"listen_addr"`
+	SocketPermission os.FileMode   `yaml:"socket_permission"`
 	ShutdownTimeout time.Duration  `yaml:"shutdown_timeout"`
 	CrtFile         string         `yaml:"crt_file"`
 	KeyFile         string         `yaml:"key_file"`
@@ -104,6 +106,7 @@ type VerifierProxyConfig struct {
 type SignerProxyConfig struct {
 	Enabled             bool          `yaml:"enabled"`
 	ListenAddr          string        `yaml:"listen_addr"`
+	SocketPermission    os.FileMode   `yaml:"socket_permission"`
 	ShutdownTimeout     time.Duration `yaml:"shutdown_timeout"`
 	CAKeyFile           string        `yaml:"ca_key_file"`
 	CACrtFile           string        `yaml:"ca_crt_file"`
@@ -145,6 +148,7 @@ func DefaultConfig() Config {
 		SignerProxy: SignerProxyConfig{
 			Enabled:         true,
 			ListenAddr:      ":8080",
+			SocketPermission: 0755,
 			ShutdownTimeout: 5 * time.Second,
 			Signer: SignerConfig{
 				SignerParams: SignerParams{

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -118,6 +118,8 @@ func (proxy *Proxy) Serve(listenAddr, crtFile, keyFile string, shutdownTimeout t
 			return err
 		}
 
+		os.Chmod(unixFile, 0777)
+
 		defer os.Remove(unixFile)
 	} else {
 		if crtFile != "" && keyFile != "" {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -88,7 +88,7 @@ type Proxy struct {
 	started         bool
 }
 
-func (proxy *Proxy) Serve(listenAddr, crtFile, keyFile string, shutdownTimeout time.Duration) error {
+func (proxy *Proxy) Serve(listenAddr, crtFile, keyFile string, shutdownTimeout time.Duration, socketPermission os.FileMode) error {
 	tlsConfig := defaultTLSConfig
 
 	// Create a graceful server.
@@ -118,7 +118,7 @@ func (proxy *Proxy) Serve(listenAddr, crtFile, keyFile string, shutdownTimeout t
 			return err
 		}
 
-		os.Chmod(unixFile, 0777)
+		os.Chmod(unixFile, socketPermission)
 
 		defer os.Remove(unixFile)
 	} else {


### PR DESCRIPTION
When using jwtproxy with nginx, the socket created needs to be writable.