### PR TITLE
git: update ignore for jwtproxy binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+cmd/jwtproxy/jwtproxy
+jwtproxy


### PR DESCRIPTION
Update the gitignore to prevent checkins of jwtproxy binary